### PR TITLE
Wrap Short URLs.

### DIFF
--- a/lib/short/adapter.ex
+++ b/lib/short/adapter.ex
@@ -3,33 +3,16 @@ defmodule Short.Adapter do
   Behaviour for creating a Short adapter.
   """
 
-  @typedoc """
-  For now just a regular String. In the future, we might want to limit what this
-  type is: For example, we only want characters that are permitted in an URL to
-  be used for the code, or we might want to limit the number of characters
-  for the code.
-  """
+  @typedoc "The code representing the shortened URL"
   @type code :: Short.Code.t
 
-  @typedoc """
-  Either a regular String or a URI if we want more control.
+  @typedoc "The URL to be shortened"
+  @type url :: Short.URL.t
 
-  TODO: Check if it is neccessary to have two possible types here.
-  """
-  @type url :: String.t | URI.t
-
-  @typedoc """
-  A wrapper around a shortened URL.
-
-  TODO: Find a better name for this type.
-  """
+  @typedoc "A wrapper around a shortened URL."
   @type shortened_url :: {code, url}
 
-  @typedoc """
-  Possible errors occuring when fetching or shortening an URL.
-
-  TODO: Find a better name for this type.
-  """
+  @typedoc "Possible errors occuring when working with Short Codes."
   @type error :: Short.CodeNotFoundError.t | Short.CodeAlreadyExistsError.t
 
   @callback get(code) :: {:ok, url} | {:error, error}

--- a/lib/short/adapter.ex
+++ b/lib/short/adapter.ex
@@ -17,4 +17,21 @@ defmodule Short.Adapter do
 
   @callback get(code) :: {:ok, url} | {:error, error}
   @callback create(url, code | nil) :: {:ok, shortened_url} | {:error, error}
+
+  # Experimenting with macros. For now, add some convenience functions that
+  # convert the "primitive" Elixir types into Short types.
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Short.Adapter
+      alias Short.{Code, URL}
+
+      def get(code) when is_binary(code), do: get(Code.new(code))
+
+      def create(url, code \\ nil)
+      def create(url, nil), do: create(url, Code.generate())
+      def create(url, code) when is_binary(code), do: create(url, Code.new(code))
+      def create(url, code) when is_binary(url), do: create(URL.new(url), code)
+    end
+  end
 end

--- a/lib/short/adapters/in_memory_adapter.ex
+++ b/lib/short/adapters/in_memory_adapter.ex
@@ -6,9 +6,9 @@ defmodule Short.Adapters.InMemoryAdapter do
   Application.
   """
 
-  @behaviour Short.Adapter
+  use Short.Adapter
 
-  alias Short.{Code, CodeAlreadyExistsError, CodeNotFoundError}
+  alias Short.{Code, CodeAlreadyExistsError, CodeNotFoundError, URL}
 
   ## Agent setup
 
@@ -30,13 +30,7 @@ defmodule Short.Adapters.InMemoryAdapter do
   ## Short Adapter implementation
 
   @impl Short.Adapter
-  @spec get(Short.Code.t | String.t) ::
-    {:ok, String.t} | {:error, CodeNotFoundError.t}
-  def get(code)
-
-  def get(code) when is_binary(code), do: get(Code.new(code))
-
-  def get(%Short.Code{} = code) do
+  def get(%Code{} = code) do
     case Map.fetch(all(), code) do
       {:ok, url} -> {:ok, url}
       :error -> {:error, CodeNotFoundError.exception(code)}
@@ -44,14 +38,8 @@ defmodule Short.Adapters.InMemoryAdapter do
   end
 
   @impl Short.Adapter
-  @spec create(String.t, Short.Code.t | nil) ::
-    {:ok, {Short.Code.t, String.t}} | {:error, CodeAlreadyExistsError.t}
-  def create(url, code \\ nil)
-
-  def create(url, nil), do: create(url, Code.generate())
-
   # TODO: This is refactorable using `with` I think.
-  def create(url, code) do
+  def create(%URL{} = url, %Code{} = code) do
     if code_exists?(code) do
       {:error, CodeAlreadyExistsError.exception(code)}
     else

--- a/lib/short/router.ex
+++ b/lib/short/router.ex
@@ -25,7 +25,7 @@ defmodule Short.Router do
     code = conn.params["code"]
 
     case adapter().create(url, code) do
-      {:ok, {code, ^url}} -> conn |> send_resp(200, "#{code}")
+      {:ok, {code, _url}} -> conn |> send_resp(200, "#{code}")
       {:error, error} -> conn |> send_resp(422, error.message)
     end
   end

--- a/lib/short/router.ex
+++ b/lib/short/router.ex
@@ -15,7 +15,7 @@ defmodule Short.Router do
   get "/:code" do
     code = conn.params["code"]
     case adapter().get(code) do
-      {:ok, url} -> redirect(conn, url)
+      {:ok, url} -> redirect(conn, to_string(url))
       {:error, _} -> conn |> send_resp(404, "not found")
     end
   end

--- a/lib/short/url.ex
+++ b/lib/short/url.ex
@@ -1,0 +1,53 @@
+defmodule Short.URL do
+  @moduledoc """
+  A Short URL.
+
+  This module defines a Short URL and the main functions for working with URLs.
+  """
+
+  @enforce_keys [:__uri]
+  defstruct [:__uri]
+
+  @type t :: %__MODULE__{
+    __uri: URI.t
+  }
+
+  @doc """
+  Returns a new wrapped URL.
+
+  ## Examples
+
+      iex> new("https://aliou.me")
+      %Short.URL{__uri: %URI{authority: "aliou.me", fragment: nil,
+        host: "aliou.me", path: nil, port: 443, query: nil,
+        scheme: "https", userinfo: nil}}
+
+  """
+  @spec new(String.t | URI.t) :: t
+  def new(uri) when is_binary(uri), do: uri |> URI.parse() |> new()
+  def new(%URI{} = uri), do: %Short.URL{__uri: uri}
+
+  @valid_schemes ["https", "http"]
+  @doc """
+  Check if the URL is valid.
+
+  ## Examples
+
+      iex> "https://aliou.me" |> new() |> valid?
+      true
+
+      iex> "http://aliou.me" |> new() |> valid?
+      true
+
+      iex> "" |> new() |> valid?
+      false
+
+      iex> "ayyyyyyy" |> new() |> valid?
+      false
+
+  """
+  @spec valid?(Short.URL.t) :: boolean
+  def valid?(%Short.URL{__uri: uri}) do
+    uri.host != nil && Enum.member?(@valid_schemes, uri.scheme)
+  end
+end

--- a/lib/short/url.ex
+++ b/lib/short/url.ex
@@ -51,3 +51,15 @@ defmodule Short.URL do
     uri.host != nil && Enum.member?(@valid_schemes, uri.scheme)
   end
 end
+
+# Allow `Short.URL`s to be interpolated in strings.
+defimpl String.Chars, for: Short.URL do
+  def to_string(url), do: url.__uri |> URI.to_string()
+end
+
+# Hide internal implementation in IEx. No reason, I just want to.
+defimpl Inspect, for: Short.URL do
+  @inspected inspect(@for)
+
+  def inspect(url, _), do: "#" <> @inspected <> "<" <> to_string(url) <> ">"
+end

--- a/test/short/adapters/in_memory_adapter_test.exs
+++ b/test/short/adapters/in_memory_adapter_test.exs
@@ -11,14 +11,14 @@ defmodule Short.Adapters.InMemoryAdapterTest do
 
   describe "get/1" do
     test "it returns an error when the code doesn't exist" do
-      code = "abc"
+      code = Short.Code.new("abc")
 
-      assert {:error, %CodeNotFoundError{code: %Short.Code{__code: ^code}}} =
+      assert {:error, %CodeNotFoundError{code: ^code}} =
         InMemoryAdapter.get(code)
     end
 
     test "it returns the code and the URL when the code exists" do
-      url = Faker.Internet.url
+      url = Faker.Internet.url |> Short.URL.new()
       code = Short.Code.generate()
 
       InMemoryAdapter.create(url, code)
@@ -29,19 +29,19 @@ defmodule Short.Adapters.InMemoryAdapterTest do
 
   describe "create/2" do
     test "it generates a code when nil is given" do
-      url = Faker.Internet.url
+      url = Faker.Internet.url |> Short.URL.new()
       assert {:ok, {_code, ^url}} = InMemoryAdapter.create(url)
     end
 
     test "it uses the given code when available" do
-      url = Faker.Internet.url
+      url = Faker.Internet.url |> Short.URL.new()
       code = Short.Code.new("my-custom-code")
 
       assert {:ok, {^code, ^url}} = InMemoryAdapter.create(url, code)
     end
 
     test "it returns an error when the code already exists" do
-      url = Faker.Internet.url
+      url = Faker.Internet.url |> Short.URL.new()
       code = Short.Code.new("my-custom-code")
 
       InMemoryAdapter.create(url, code)
@@ -51,7 +51,7 @@ defmodule Short.Adapters.InMemoryAdapterTest do
     end
 
     test "it returns the existing code if the URL already exists" do
-      url = Faker.Internet.url
+      url = Faker.Internet.url |> Short.URL.new()
       code = Short.Code.new("my-custom-code")
 
       InMemoryAdapter.create(url, code)

--- a/test/short/url_test.exs
+++ b/test/short/url_test.exs
@@ -1,0 +1,6 @@
+defmodule Short.URLTest do
+  use ExUnit.Case, async: true
+
+  import Short.URL
+  doctest Short.URL
+end


### PR DESCRIPTION
- Create a URL wrapper.
- Handle adapter boilerplate code using a `__using__` macro.
- Update InMemoryAdapter to only handle Short types.