### PR TITLE
implement #3 and improve URL validation

### DIFF
--- a/lib/short/url.ex
+++ b/lib/short/url.ex
@@ -65,25 +65,25 @@ defmodule Short.URL do
     |> valid_scheme
     |> nil_elements
   end
-  
+
   defp valid_hostname({:ok, %URI{} = uri}) do
     case :inet.gethostbyname(to_charlist uri.host) do
       {:error, _} -> {:error, "invalid hostname"}
       {:ok, _}    -> {:ok, uri}
     end
   end
-  
+
   defp valid_hostname({:error, errstr}) do
     {:error, errstr}
   end
-  
+
   defp valid_scheme({:ok, %URI{} = uri}) do
     case Enum.member?(@valid_schemes, uri.scheme) do
       false -> {:error, "invalid scheme"}
       true  -> {:ok, uri}
     end
   end
-  
+
   defp valid_scheme({:error, errstr}) do
     {:error, errstr}
   end
@@ -94,15 +94,15 @@ defmodule Short.URL do
       true  -> {:ok, uri}
     end
   end
-  
+
   defp nil_elements({:ok, %URI{} = uri}) do
     case uri do
       %URI{scheme: nil} -> {:error, "scheme cannot be nil"}
       %URI{host: nil}   -> {:error, "host cannot be nil"}
-      uri -> {:ok, uri}      
+      uri -> {:ok, uri}
     end
   end
-  
+
   defp nil_elements({:error, errstr}) do
     {:error, errstr}
   end

--- a/test/short/url_test.exs
+++ b/test/short/url_test.exs
@@ -3,4 +3,20 @@ defmodule Short.URLTest do
 
   import Short.URL
   doctest Short.URL
+
+  test "should allow well formed URL" do
+    assert true = Short.URL.new("https://github.com/") |> Short.URL.valid?
+  end
+
+  test "should error on a non http/https URL" do
+    refute Short.URL.new("ftp://github.com/") |> Short.URL.valid?
+  end
+
+  test "should error on no scheme" do
+    refute Short.URL.new("weuiewougew") |> Short.URL.valid?
+  end
+
+  test "should error on invalid hostname" do
+    refute Short.URL.new("http://ewoweowe/") |> Short.URL.valid?
+  end
 end


### PR DESCRIPTION
new `is_valid` function which asks
  - does the hostname exist and resolve?
  - is there a scheme?
  - is the scheme in the set defined in @valid_schemes

presently the function yields an atom and a helpful string (or the URI) but that gets dropped by `is_valid?`, so that could be addressed maybe.

adds tests. 